### PR TITLE
Added TSMP2 container

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
-# docker-images
+# containers 
 
-Dockerfiles for images hosted at the [HPSCTerrSys DockerHub repository]. 
+This repo contains the Dockerfiles used to build the images hosted at the [HPSCTerrSys DockerHub repository]. 
 
-Run `docker pull <repository>:<tag>` to retrieve the desired image.
+Run `podman pull <repository>:<tag>` to retrieve the desired image.
 
 ## Supported images
 
-| Image | Version |         `docker pull` command         |     Usage guide    |
-|:-----:|:-------:|:-------------------------------------:|:------------------:|
-| CLM5  |   0.4   | `docker pull hpscterrsys/clm5:latest` | [link][clm5-usage] |
-| eCLM  |   0.2   | `docker pull hpscterrsys/eclm:latest` | [link][eclm-usage] |
-
+| Image | Version |         `podman pull` command          |     Usage guide     |
+|:-----:|:-------:|:--------------------------------------:|:-------------------:|
+| CLM5  |   0.4   | `podman pull hpscterrsys/clm5:latest`  | [link][clm5-usage]  |
+| eCLM  |   0.2   | `podman pull hpscterrsys/eclm:latest`  | [link][eclm-usage]  |
+| TSMP2 |   0.2   | `podman pull hpscterrsys/tsmp2:latest` | [link][tsmp2-usage] |
 
 [HPSCTerrSys DockerHub repository]: https://hub.docker.com/u/hpscterrsys
 [clm5-usage]: https://hub.docker.com/r/hpscterrsys/clm5
 [eclm-usage]: https://hub.docker.com/r/hpscterrsys/eclm
+[tsmp2-usage]: https://hub.docker.com/r/hpscterrsys/tsmp2

--- a/tsmp2/Dockerfile
+++ b/tsmp2/Dockerfile
@@ -1,0 +1,54 @@
+# escape=`
+FROM hpscterrsys/eclm:0.2
+
+#
+# TODO: Specify image metadata following OCI format spec: https://github.com/opencontainers/image-spec/blob/main/spec.md
+#
+# LABEL ...
+
+
+# Download compiler toolchain and libraries
+RUN <<EOF
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y tcl-dev tk-dev liblzma-dev
+EOF
+
+# Build prep
+ENV VER_ECCODES="2.46.0"
+ENV VER_HYPRE="3.1.0"
+ENV CC=mpicc FC=mpifort CXX=mpicxx
+ENV TMP=/tmp/bld
+ENV INSTALL_PREFIX=/usr/local
+ENV MAKEFLAGS=-j8
+ENV MPI_HOME=/usr/lib/x86_64-linux-gnu/openmpi
+ENV LD_LIBRARY_PATH=/usr/local/lib
+
+RUN <<EOF
+# Install Hypre
+mkdir -p $TMP && cd $TMP
+wget https://github.com/hypre-space/hypre/archive/v${VER_HYPRE}.tar.gz
+tar xf v${VER_HYPRE}.tar.gz
+cd hypre-${VER_HYPRE}
+cmake -S src -B bld                               \
+      -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}"  \
+      -DMPI_INCLUDE_DIR="${MPI_HOME}/include"     \
+      -DHYPRE_ENABLE_OPENMP="ON"
+cmake --build bld
+cmake --install bld
+EOF
+
+RUN <<EOF
+# Install ecCodes
+wget https://github.com/ecmwf/eccodes/archive/refs/tags/${VER_ECCODES}.tar.gz
+tar xf ${VER_ECCODES}.tar.gz
+cd eccodes-${VER_ECCODES}
+cmake -S . -B bld -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}/eccodes-${VER_ECCODES}
+cmake --build bld --parallel 4
+cmake --install bld
+cd / && rm -rvf $TMP
+EOF
+
+USER root
+WORKDIR /root
+CMD ["/bin/bash","-l"]

--- a/tsmp2/Dockerfile_dev
+++ b/tsmp2/Dockerfile_dev
@@ -18,6 +18,7 @@ EOF
 USER root
 WORKDIR /root
 RUN <<EOF
+echo "export SYSTEMNAME=UBUNTU"                                >> .bash_profile
 echo "export CC=mpicc FC=mpif90 CXX=mpicxx"                    >> .bash_profile
 echo "export OMPI_ALLOW_RUN_AS_ROOT=1"                         >> .bash_profile
 echo "export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1"                 >> .bash_profile

--- a/tsmp2/Dockerfile_dev
+++ b/tsmp2/Dockerfile_dev
@@ -1,0 +1,32 @@
+# escape=`
+FROM hpscterrsys/tsmp2:0.2
+
+#
+# TODO: Specify image metadata following OCI format spec: https://github.com/opencontainers/image-spec/blob/main/spec.md
+#
+# LABEL ...
+
+
+# Install dev tools
+RUN <<EOF
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y vim gdb
+EOF
+
+# Dev environment presets
+USER root
+WORKDIR /root
+RUN <<EOF
+echo "export CC=mpicc FC=mpif90 CXX=mpicxx"                    >> .bash_profile
+echo "export OMPI_ALLOW_RUN_AS_ROOT=1"                         >> .bash_profile
+echo "export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1"                 >> .bash_profile
+echo "export PIP_BREAK_SYSTEM_PACKAGES=1"                      >> .bash_profile
+echo "export CMAKE_INSTALL_PREFIX=/root/.local"                >> .bash_profile
+echo "export LD_LIBRARY_PATH=/usr/local/lib:/root/.local/lib"  >> .bash_profile
+echo "export PATH=${PATH}:/root/.local/bin"                    >> .bash_profile
+echo "export SW=/root/.local"                                  >> .bash_profile
+echo "export EDITOR=vim"                                       >> .bash_profile
+mkdir -vp .local/{bin,lib}
+EOF
+CMD ["/bin/bash","-l"]

--- a/tsmp2/README.md
+++ b/tsmp2/README.md
@@ -1,0 +1,81 @@
+# TSMP2 Docker Build Guide
+
+This guide requires [Podman](https://docs.podman.io/en/v4.6.1/index.html). If you're on Debian/Ubuntu, run
+
+```sh
+sudo apt update
+sudo apt-get install -y podman
+```
+
+Otherwise, head over to the [Podman install guide](http://podman.io/docs/installation) and follow the instructions
+specific to your system.
+
+## Building the TSMP2 container
+
+> [!NOTE]
+> This section is only relevant for developers who have push access rights to the [HPSCTerrSys DockerHub](https://hub.docker.com/u/hpscterrsys).
+
+1. Build TSMP2 base image.
+
+```sh
+podman build --tag hpscterrsys/tsmp2:latest --tag hpscterrsys/tsmp2:0.2 .
+```
+
+2. Push TSMP2 base image to DockerHub.
+
+```sh
+podman login --username $USER docker.io
+podman push hpscterrsys/tsmp2:latest
+podman push hpscterrsys/tsmp2:0.2
+```
+
+3. Build TSMP2 dev image.
+
+```sh
+podman build --tag hpscterrsys/tsmp2:latest-dev --tag hpscterrsys/tsmp2:0.2-dev -f Dockerfile_dev
+```
+
+4. Push TSMP2 dev image to DockerHub.
+
+```sh
+podman push hpscterrsys/tsmp2:latest-dev
+podman push hpscterrsys/tsmp2:0.2-dev
+podman logout
+```
+
+## Using the container image for local development
+
+First we configure file sharing between the host machine and the container image. Decide which
+local folder you'd like to expose to the container image, then save its full path to `WORKDIR`:
+
+```sh
+WORKDIR=/home/user/shared_folder
+```
+
+Then create a container named `tsmp2-dev`.
+
+```sh
+podman run --name tsmp2-dev -it -v ${WORKDIR}:/root/$(basename ${WORKDIR}) hpscterrsys/tsmp2:latest-dev
+```
+
+The command above will also start `tsmp2-dev`. Verify that everything works by running these commands:
+
+```sh
+root@e06d13d06436:~# pwd                  # $HOME directory
+/root
+root@e06d13d06436:~# ls                   # Should see your WORKDIR here
+shared_folder
+root@e06d13d06436:~# echo $CC $FC $CXX    # Preset compilers in this dev image
+mpicc mpif90 mpicxx
+```
+
+If the container has been stopped, simply run `podman start -ai tsmp2-dev` to restart it. `podman run` is only done once, *i.e.* during
+container creation. It's also important to know these commands:
+
+- `podman ps -a`: list created containers
+- `podman images`: list downloaded images
+- `podman rm`: Delete existing container
+- `podman rmi`: Delete existing image
+
+The mentioned `podman` commands are sufficient to manage your local `tsmp2-dev` image. For more information regarding `podman` usage, visit the [Podman tutorial](https://docs.podman.io/en/v4.6.1/Tutorials.html).
+


### PR DESCRIPTION
`hpscterrsys/tsmp2` images is hosted at https://hub.docker.com/r/hpscterrsys/tsmp2/tags

Usage:
```sh
# Install podman on Ubuntu. For other platforms see http://podman.io/docs/installation
sudo apt-get -y install podman

# Barebones TSMP2 environment. Suitable for CI/CD workflows
podman run --name tsmp2 -it hpscterrsys/tsmp2:0.2

# TSMP2 dev environment. Has vim, gdb and preset env vars.
podman run --name tsmp2-dev -it hpscterrsys/tsmp2:0.2-dev
```